### PR TITLE
Convert commentaries into annotations

### DIFF
--- a/src/pip/__init__.py
+++ b/src/pip/__init__.py
@@ -3,8 +3,7 @@ from typing import List, Optional
 __version__ = "21.2.dev0"
 
 
-def main(args=None):
-    # type: (Optional[List[str]]) -> int
+def main(args: (Optional[List[str]]) = None) -> int:
     """This is an internal API only meant for use by pip's own console scripts.
 
     For additional details, see https://github.com/pypa/pip/issues/7498.


### PR DESCRIPTION
As I said on the pypa/pip PR #10004, it is necessary to remove the comments and use the `typing` annotations instead.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
