### PR TITLE
Better error message if the file is not found on sessions

### DIFF
--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -219,7 +219,9 @@ class LocalFSAdapter(BaseAdapter):
             stats = os.stat(pathname)
         except OSError as exc:
             resp.status_code = 404
-            resp.raw = exc
+            # format the error message
+            exc_message = f"{type(exc).__name__}: {exc}"
+            resp.raw = io.BytesIO(exc_message.encode("utf8"))
         else:
             modified = email.utils.formatdate(stats.st_mtime, usegmt=True)
             content_type = mimetypes.guess_type(pathname)[0] or "text/plain"


### PR DESCRIPTION
Make a friendlier error message when pip finds an invalid URL/path.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
