### PR TITLE
Use more references to Nox instead of tox

### DIFF
--- a/docs/html/development/getting-started.rst
+++ b/docs/html/development/getting-started.rst
@@ -154,7 +154,7 @@ To build it locally, run:
 
 .. code-block:: console
 
-    $ tox -e docs
+    $ nox -s docs
 
 The built documentation can be found in the ``docs/build`` folder.
 


### PR DESCRIPTION
This is the first step. Recommend `nox -s docs` instead of using tox.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
